### PR TITLE
Make clientId configurable from connect options

### DIFF
--- a/src/mqtt.service.ts
+++ b/src/mqtt.service.ts
@@ -74,6 +74,8 @@ export class MqttService {
     const hostname = options.hostname || 'localhost';
     const port = options.port || 1884;
     const path = options.path || '/';
+    this.clientId = options.clientId || this.clientId;
+
     this.url = `${protocol}://${hostname}:${port}/${path}`;
     this.state.next(MqttConnectionState.CONNECTING);
     if (!client) {


### PR DESCRIPTION
IBM IoT requires specific clientIds. This change enables this.clientId to be passed in on the config object.