### PR TITLE
verify existence of granted argument on subscribe callback

### DIFF
--- a/src/mqtt.service.ts
+++ b/src/mqtt.service.ts
@@ -144,14 +144,16 @@ export class MqttService {
           () => {
             const subscription: Subscription = new Subscription();
             this.client.subscribe(filterString, (err, granted: ISubscriptionGrant[]) => {
-              granted.forEach((granted_: ISubscriptionGrant) => {
-                if (granted_.qos === 128) {
-                  delete this.observables[granted_.topic];
-                  this.client.unsubscribe(granted_.topic);
-                  rejected.error(`subscription for '${granted_.topic}' rejected!`);
-                }
-                this._onSuback.emit({ filter: filterString, granted: granted_.qos !== 128 });
-              });
+              if(granted) { // granted can be undefined when an error occurs when the client is disconnecting
+                  granted.forEach((granted_: ISubscriptionGrant) => {
+                      if (granted_.qos === 128) {
+                          delete this.observables[granted_.topic];
+                          this.client.unsubscribe(granted_.topic);
+                          rejected.error(`subscription for '${granted_.topic}' rejected!`);
+                      }
+                      this._onSuback.emit({filter: filterString, granted: granted_.qos !== 128});
+                  });
+              }
             });
             subscription.add(() => {
               delete this.observables[filterString];


### PR DESCRIPTION
### Issue
When subscribing, an error can occur (for example the client is disconnecting). In the callback of the subscribe, this line of code assumes the granted array is always defined, however this isn't the case when an error occurred: https://github.com/sclausen/ngx-mqtt/blob/6.1.0/src/mqtt.service.ts#L147

### PR
This PR adds a guard on the granted array, verifying its existence before continuing.