### PR TITLE
updated mqtt dependency to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "10.3.2",
     "ecstatic": ">=3.2.0",
     "ssri": ">=6.0.0",
-    "mqtt": "github:mqttjs/MQTT.js#62641d6ec22e4e51b1cacd3f692965d44a09d03e"
+    "mqtt": "^3.0.0"
   },
   "devDependencies": {
     "@angular/common": "^6.0.4",


### PR DESCRIPTION
This solves the npm installation issue on Windows.