### PR TITLE
Fixes error TS2314 when upgrading to Angular 10

### DIFF
--- a/src/mqtt.module.ts
+++ b/src/mqtt.module.ts
@@ -17,7 +17,7 @@ export const MqttClientService = new InjectionToken<IMqttClient>('NgxMqttClientS
 
 @NgModule()
 export class MqttModule {
-  static forRoot(config: IMqttServiceOptions, client?: IMqttClient): ModuleWithProviders<any> {
+  static forRoot(config: IMqttServiceOptions, client?: IMqttClient): ModuleWithProviders<MqttModule> {
     return {
       ngModule: MqttModule,
       providers: [

--- a/src/mqtt.module.ts
+++ b/src/mqtt.module.ts
@@ -17,7 +17,7 @@ export const MqttClientService = new InjectionToken<IMqttClient>('NgxMqttClientS
 
 @NgModule()
 export class MqttModule {
-  static forRoot(config: IMqttServiceOptions, client?: IMqttClient): ModuleWithProviders {
+  static forRoot(config: IMqttServiceOptions, client?: IMqttClient): ModuleWithProviders<any> {
     return {
       ngModule: MqttModule,
       providers: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,8 @@ module.exports = {
   devtool: 'inline-source-map',
 
   resolve: {
-    extensions: ['.ts', '.js']
+    extensions: ['.ts', '.js'],
+    mainFields: [ 'es2015', 'browser', 'module', 'main']
   },
 
   entry: ['./vendor/mqtt.min.js', helpers.root('./src/index.ts')],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,7 @@ module.exports = {
   devtool: 'inline-source-map',
 
   resolve: {
-    extensions: ['.ts', '.js'],
-    mainFields: [ 'es2015', 'browser', 'module', 'main']
+    extensions: ['.ts', '.js']
   },
 
   entry: ['./vendor/mqtt.min.js', helpers.root('./src/index.ts')],


### PR DESCRIPTION
After upgrading to Angular 10, I get the following error when compiling the application just by importing the library in my App Module:

```
ERROR in node_modules/ngx-mqtt/src/mqtt.module.d.ts:7:72 - error TS2314: Generic type 'ModuleWithProviders<T>' requires 1 type argument(s).

7     static forRoot(config: IMqttServiceOptions, client?: IMqttClient): ModuleWithProviders;
                                                                         ~~~~~~~~~~~~~~~~~~~
```

This may not be the optimal fix, but wanted to submit for review