### PR TITLE
fix(bug): changed env var from MQTT-DISABLE-HOOK to MQTT_DISABLE_HOOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,6 @@ It's substituted with `npm run publish`, which will correctly build and publish 
 
 ngx-mqtt depends on mqtt package which uses node globals.
 In order to make it run inside browser it includes a postinstall script which patches Angular webpack config of the project it was imported into.
-To disable this, you have to set `mqtt-disable-hook` environmental variable while installing this package.
+To disable this, you have to set `MQTT_DISABLE_HOOK` environmental variable while installing this package.
+`MQTT_DISABLE_HOOK=true npm i`
 

--- a/projects/ngx-mqtt/postinstall.js
+++ b/projects/ngx-mqtt/postinstall.js
@@ -1,4 +1,5 @@
-if (process.env['mqtt-disable-hook']) {
+if (process.env['MQTT_DISABLE_HOOK']) {
+  console.info('NGX-MQTT: postinstall hook disabled, MQTT_DISABLE_HOOK')
   return 0;
 }
 


### PR DESCRIPTION
using minus in env var name causes additional quotes, to avoid explanation of that easier to use _