### PR TITLE
Allow to retrieve connection state

### DIFF
--- a/projects/ngx-mqtt/src/lib/mqtt.service.ts
+++ b/projects/ngx-mqtt/src/lib/mqtt.service.ts
@@ -102,10 +102,16 @@ export class MqttService {
   public get onSuback(): EventEmitter<IOnSubackEvent> {
     return this._onSuback;
   }
+  
+  /** An actual connection state **/
+  public get connectionState(): MqttConnectionState {
+    return this.state.value;
+  }
+  
   /** a map of all mqtt observables by filter */
   public observables: { [filterString: string]: Observable<IMqttMessage> } = {};
   /** the connection state */
-  public state: Subject<MqttConnectionState> = new BehaviorSubject<MqttConnectionState>(MqttConnectionState.CLOSED);
+  public state: BehaviorSubject<MqttConnectionState> = new BehaviorSubject<MqttConnectionState>(MqttConnectionState.CLOSED);
   /** an observable of the last mqtt message */
   public messages: Subject<IMqttMessage> = new Subject<IMqttMessage>();
 


### PR DESCRIPTION
In actual state we can't retrieve mqtt connection state.

This is because state is wrapped to a Subject instead of the BehaviorSubject.

![image](https://user-images.githubusercontent.com/10392319/158808040-a561f709-4e0f-4613-bc77-46518ca194b9.png)

With this change we'll be able to get that by new property - `connectionState`