### PR TITLE
Adding all supported protocols

### DIFF
--- a/projects/ngx-mqtt/src/lib/mqtt.model.ts
+++ b/projects/ngx-mqtt/src/lib/mqtt.model.ts
@@ -19,7 +19,7 @@ export interface IMqttServiceOptions extends IClientOptions {
   port?: number;
   /** the path parameters to connect to e.g. `/mqtt` */
   path?: string;
-  protocol?: 'wss' | 'ws';
+  protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'tls' | 'wxs' | 'alis';
   /** if the url is provided, hostname, port path and protocol are ignored */
   url?: string;
 }


### PR DESCRIPTION
I need to use 'tcp' protocol my project, I see it is supported by MQTT.js but this type restriction does not let me use it. I modified the type to allow all [MQTT.js supported protocols](https://github.com/mqttjs/MQTT.js#mqttconnecturl-options).